### PR TITLE
Benchmark changes to find()

### DIFF
--- a/benchmark.d
+++ b/benchmark.d
@@ -102,47 +102,40 @@ T[] andrei_find2(T)(T[] haystack, T[] needle)
     return haystack[$ .. $];
 }
 
-T[] faster_find(T)(T[] haystack, T[] needle)
+T[] faster_find(T)(T[] haystack, T[] needle) pure nothrow
 {
-    if (needle.length == 0) return haystack;
-    immutable lastIndex = needle.length - 1;
-    immutable last = needle[lastIndex];
-	size_t j = needle.length - 1, skip = 0;
-	
-    main_loop: for (; j < haystack.length; ++j)
-    {
-        if (haystack[j] != last) continue;
-		
-        immutable k = j - lastIndex;
-		size_t i = 0;
+    if (needle.length == 0) return haystack[$..$];
+	if (needle.length > haystack.length) return haystack[$..$];
 
-        do {
-            if (needle[i] != haystack[k + i]) {
-				while (skip < needle.length - 1 && needle[$ - 2 - skip] != last) { ++skip; }
+	immutable end = needle.length - 1;
+	size_t j = end, skip = 0;
+	
+    while(++j < haystack.length)
+    {
+        if (haystack[j] != needle[end]) continue;
+		
+        for(size_t i = 1, k = 0; i < needle.length; ++i, ++k) {
+            if (haystack[j - needle.length + i] != needle[k]) {
+				while (skip < end && needle[end - 1 - skip] != needle[end]) { ++skip; }
 				j += skip;
 				goto main_loop2;
 			}
-			++i;
-        } while(i < lastIndex);
-		return haystack[k .. $];
+        }
+		return haystack[j - end .. $];
     }
     return haystack[$ .. $];
 
-	main_loop2: for (; j < haystack.length; ++j)
+	main_loop2: while(++j < haystack.length)
     {
-        if (haystack[j] != last) continue;
+        if (haystack[j] != needle[end]) continue;
 		
-        immutable k = j - lastIndex;
-		size_t i = 0;
-
-        do {
-            if (needle[i] != haystack[k + i]) {
-				j += skip;				
+        for(size_t i = 1, k = 0; i < needle.length; ++i, ++k) {
+            if (haystack[j - needle.length + i] != needle[k]) {
+				j += skip;
 				continue main_loop2;
 			}
-			++i;
-        } while(i < lastIndex);
-		return haystack[k .. $];
+        }
+		return haystack[j - end .. $];
     }
     return haystack[$ .. $];
 }

--- a/benchmark.d
+++ b/benchmark.d
@@ -12,7 +12,7 @@ bool halt_on_error = false;
 bool verbose_errors = false;
 bool more_statistics = false;
 
-string[] names = ["std", "manual", "A2Phobos", "Chris", "Andrei", "Andrei2"];
+string[] names = ["std", "manual", "A2Phobos", "Chris", "Andrei", "Andrei2", "Faster"];
 
 string manual_find(string haystack, string needle) {
     size_t i=0;
@@ -102,6 +102,50 @@ T[] andrei_find2(T)(T[] haystack, T[] needle)
     return haystack[$ .. $];
 }
 
+T[] faster_find(T)(T[] haystack, T[] needle)
+{
+    if (needle.length == 0) return haystack;
+    immutable lastIndex = needle.length - 1;
+    immutable last = needle[lastIndex];
+	size_t j = needle.length - 1, skip = 0;
+	
+    main_loop: for (; j < haystack.length; ++j)
+    {
+        if (haystack[j] != last) continue;
+		
+        immutable k = j - lastIndex;
+		size_t i = 0;
+
+        do {
+            if (needle[i] != haystack[k + i]) {
+				while (skip < needle.length - 1 && needle[$ - 2 - skip] != last) { ++skip; }
+				j += skip;
+				goto main_loop2;
+			}
+			++i;
+        } while(i < lastIndex);
+		return haystack[k .. $];
+    }
+    return haystack[$ .. $];
+
+	main_loop2: for (; j < haystack.length; ++j)
+    {
+        if (haystack[j] != last) continue;
+		
+        immutable k = j - lastIndex;
+		size_t i = 0;
+
+        do {
+            if (needle[i] != haystack[k + i]) {
+				j += skip;				
+				continue main_loop2;
+			}
+			++i;
+        } while(i < lastIndex);
+		return haystack[k .. $];
+    }
+    return haystack[$ .. $];
+}
 
 immutable LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -195,6 +239,8 @@ auto doBenchmark(string haystack, string needle)
         results ~= andrei_find(haystack, needle);
     },{
         results ~= andrei_find2(haystack, needle);
+    },{
+        results ~= faster_find(haystack, needle);
     })(1);
 
     { // Correctness check
@@ -217,14 +263,15 @@ auto doBenchmark(string haystack, string needle)
     }
 
     // normalize
-    long m = min(res[0].length, res[1].length, res[2].length, res[3].length, res[4].length, res[5].length);
+    long m = min(res[0].length, res[1].length, res[2].length, res[3].length, res[4].length, res[5].length, res[6].length);
     return [
         100 * res[0].length / m,
         100 * res[1].length / m,
         100 * res[2].length / m,
         100 * res[3].length / m,
         100 * res[4].length / m,
-        100 * res[5].length / m];
+        100 * res[5].length / m,
+        100 * res[6].length / m];
 }
 
 void manyRuns(long n, long[] function(int) gen)

--- a/my_searching.d
+++ b/my_searching.d
@@ -1778,16 +1778,10 @@ if (isRandomAccessRange!R1 && isBidirectionalRange!R2
     static if (hasLength!R2)
     {
         immutable needleLength = needle.length;
-        immutable lastIndex = needleLength - 1;
-        immutable last = needle[lastIndex];
-		immutable secondlast = needle[lastIndex - 1];
     }
     else
     {
         immutable needleLength = walkLength(needle.save);
-        immutable lastIndex = needleLength - 1;
-        immutable last = needle[lastIndex];
-		immutable secondlast = needle[lastIndex - 1];
     }
     if (needleLength > haystack.length)
     {
@@ -1795,14 +1789,12 @@ if (isRandomAccessRange!R1 && isBidirectionalRange!R2
     }
     static if (isRandomAccessRange!R2)
     {
-        size_t skip = 1;
-        while (skip < needleLength && needle[needleLength - 1 - skip] != last)
-        {
-          ++skip;
-        }
-		size_t j = lastIndex;
+        immutable lastIndex = needleLength - 1;
+        immutable last = needle[lastIndex];
 
-loop:	while( j < haystack.length ) {
+		size_t j = lastIndex, skip = 0;
+
+loop: while( j < haystack.length ) {
             if (!binaryFun!pred(haystack[j], last)) {
 				++j;
 				continue;
@@ -1810,11 +1802,19 @@ loop:	while( j < haystack.length ) {
    		    immutable k = j - lastIndex;
    		    // last elements match
    		    for (size_t i = lastIndex; i;) {
-   				if (!binaryFun!pred(haystack[k + i - 1], needle[i - 1])) {
-					j += skip;
-					goto loop;
+   				if (binaryFun!pred(haystack[k + i - 1], needle[i - 1])) {
+					--i;
+					continue;
 				}
-				--i;
+				if (skip == 0) {
+					skip = 1;
+			        while (skip < needleLength && !binaryFun!pred(needle[needleLength - 1 - skip], last))
+			        {
+			          ++skip;
+			        }
+				}
+				j += skip;
+				goto loop;
 	        }
 			return haystack[k..$];
         }


### PR DESCRIPTION
Heya,

Im guessing that the benchmarks, I want the other tests to be larger? Not much left to squeeze. Almost all comes from the compare to zero in the match test loop.

Search in Alice in Wonderland
       std: 165 ±2  
    manual: 134 ±1  
  A2Phobos: 100 ±0  
     Chris: 193 ±2  
    Andrei: 282 ±2 
   Andrei2: 120 ±1  

AFTER
 std: 171 ±3 
  manual: 149 ±12 
  A2Phobos: 103 ±6  
   Chris: 205 ±11 
   Andrei: 294 ±7  
    Andrei2: 126 ±5  
Search in random short strings
       std: 165 ±10 
    manual: 160 ±18 
  A2Phobos: 100 ±0  
     Chris: 174 ±15 
    Andrei: 145 ±18 
   Andrei2: 106 ±4  

AFTER
       **std: 169 ±12 **
  *\*  manual: 160 ±12** 
 *\*  A2Phobos: 100 ±0  **
    *\* Chris: 181 ±20 **
   *\*  Andrei: 147 ±20 **
 *\*   Andrei2: 108 ±4*\*  
Mismatch in random long strings
       std: 153 ±22 
    manual: 189 ±68 
  A2Phobos: 100 ±0  
     Chris: 253 ±89 
    Andrei: 326 ±131
   Andrei2: 119 ±6  

AFTER
       **std: 158 ±25 **
 *\*    manual: 202 ±76 **
 *\*  A2Phobos: 100 ±0  **
*\*     Chris: 263 ±98 **
*\*    Andrei: 337 ±142**
*\*   Andrei2: 122 ±5*\*  
Search random haystack with random needle
       std: 150 ±24 
    manual: 153 ±26 
  A2Phobos: 101 ±1  
     Chris: 205 ±32 
    Andrei: 256 ±39 
   Andrei2: 123 ±6  

AFTER
       **std: 157 ±30 **
*\*    manual: 162 ±30 **
*\*  A2Phobos: 101 ±2  **
*\*     Chris: 211 ±35 **
*\*    Andrei: 261 ±42 **
*\*   Andrei2: 125 ±6**  
 (avg slowdown vs fastest; absolute deviation)
CPU ID: GenuineIntel Celeron(R) Dual-Core CPU  
